### PR TITLE
Add Copyright Information to LCSD 3 and add additional acceptance rules

### DIFF
--- a/drafts/LCSD3.md
+++ b/drafts/LCSD3.md
@@ -8,7 +8,7 @@ Start Date: 2023-11-05
 
 Last Review Date: 2023-11-19
 
-Last Revision Date: 2023-11-05
+Last Revision Date: 2023-11-25
 
 Revision Number: 1
 

--- a/drafts/LCSD3.md
+++ b/drafts/LCSD3.md
@@ -10,7 +10,9 @@ Last Review Date: 2023-11-19
 
 Last Revision Date: 2023-11-05
 
-Revision Number: 0
+Revision Number: 1
+
+Copyright (C) 2023 Connor Horman. Copyright License in §5.
 
 ## §1 Canonical Target Names
 
@@ -29,7 +31,8 @@ An environment is information about the target. It may include:
 * An object format specification, and
 * A abi subfield (for example, identifying the x32 abi for `x86_64`).
 
-Toolchains that support a target should accept the target in its canonical form.
+Toolchains that support a target should accept the target in its canonical form. 
+Toolchains should not differentiate between targets with different vendors, except as configured explicitly by the user, or to select toolchain components that are executed. 
 
 ## §2 Noncanonical Target Names
 
@@ -47,6 +50,8 @@ The canonicalization process is as follows:
 3. Component Canonicalization - Each aliased/noncanonical component is replaced with its canonical name according to the prescriptions in §3.
 4. Any additional steps according to the prescriptions in §3.
 
+Toolchains that support a target may accept the target in a noncanonical form. If it does, it should support the target in its canonical form, and all forms of the target should be treated identically, except as configured explicitly by the user, or to select toolchain components that are executed.
+
 ## §3 Special Publications Prescribing Canonical Forms
 
 The Toolchains and Target Naming Working Committee may make special publications regarding the process and forms for canonicalizing targets, including:
@@ -57,3 +62,9 @@ The Toolchains and Target Naming Working Committee may make special publications
 * Additional canonicalization steps which need to be prescribed.
 
 Additionally, the Toolchains and Target Naming Working Committee should maintain the information above, except as to canonicalization steps, in a machine readable format. It may maintain computer programs which perform the translation of noncanonical targets (or a subset thereof) to canonical targets, and it may support compiler toolchains and other programs that use canonical and noncanonical targets.
+
+## §4 Copyright License
+
+This document is released under the terms of the CC BY 4.0. You may copy, distribute, publish, modify, or otherwise use this document provided that this notice is left intact and that you do not use technological measures to prevent further use.
+
+A Copy of the license is accessible at <https://creativecommons.org/licenses/by/4.0/legalcode.en>.


### PR DESCRIPTION
This indicates that toolchains *may* accept a non-canonical form of a target, and if it does, it should accept the canonical form and treat them identically. It also discourages differentiating between targets that different only in the vendor field.